### PR TITLE
cepheus: overlay: Enable fp screen off unlock feature and turn off by…

### DIFF
--- a/overlay-lineage/frameworks/base/core/res/res/values/cr_config.xml
+++ b/overlay-lineage/frameworks/base/core/res/res/values/cr_config.xml
@@ -48,4 +48,11 @@
     <!-- Does the battery LED support multiple colors?
          Used to decide if the user can change the colors -->
     <bool name="config_multiColorBatteryLed">false</bool>
+
+      <!-- Whether to enable fp unlock when screen turns off on udfps devices -->
+    <bool name="config_screen_off_udfps_enabled">true</bool>
+
+    <!-- Default value for fp screen off unlock toggle, it only works for the devices that support
+         fp screen off unlock-->
+    <bool name="config_screen_off_udfps_default_on">true</bool>
 </resources>


### PR DESCRIPTION
… default

Bug: 389002332
Flag: android.hardware.biometrics.screen_off_unlock_udfps Test: 1. FP screen off unlock should be included in settings
      2. FP screen off unlock should be disabled by default